### PR TITLE
修复oled.c中的DrawFilledRectangle函数

### DIFF
--- a/library/stm32_hal_ch1116/stm32_hal_ch1116/Core/Src/oled.c
+++ b/library/stm32_hal_ch1116/stm32_hal_ch1116/Core/Src/oled.c
@@ -392,7 +392,7 @@ void OLED_DrawRectangle(uint8_t x, uint8_t y, uint8_t w, uint8_t h, OLED_ColorMo
  */
 void OLED_DrawFilledRectangle(uint8_t x, uint8_t y, uint8_t w, uint8_t h, OLED_ColorMode color) {
   for (uint8_t i = 0; i < h; i++) {
-    OLED_DrawLine(x, y + i, x + w, y + i, color);
+    OLED_DrawLine(x, y+i, x+w-1, y+i, color);
   }
 }
 


### PR DESCRIPTION
一般来说，我们说画多宽多高指的是这个形状亮起的区域，宽有多少点，高有多少点，这样的话，横向坐标范围应该是 `[x, x+w-1]` ，纵向坐标范围也类同是 `[y, y+h-1]` ； 从循环中可以看出纵向坐标范围没问题，但是每行横向坐标多了一个点，所以把这个多的点减掉就可以了。
[Issues#3](https://github.com/BaudDance/LEDDrive/issues/3)